### PR TITLE
Hide shorts shelf on the subscription page

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -132,6 +132,10 @@ function hideShortsVideosSubscriptionFeed(isMobile) {
                     parent.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode.style.display = 'none';
                 }
             });
+            const shortsShelfElements = document.querySelectorAll('ytd-rich-shelf-renderer[is-shorts]');
+            shortsShelfElements.forEach(element => {
+                element.parentNode.parentNode.style.display = "none";
+            });
         }
     } else {
         if (location.href.includes('youtube.com/feed/subscriptions')) {


### PR DESCRIPTION
I just got the new UI changes so this PR will hide the shorts shelf on the subscription page.
![msedge_ZkSYUiEg74](https://user-images.githubusercontent.com/64634605/235364917-52e5ee30-8d8a-461d-aa2f-b78c19e70a49.png)
![SiqgXxWzht](https://user-images.githubusercontent.com/64634605/235364921-5e9d0b1a-4160-43f5-b9d5-3aa3fe16d6bd.png)
